### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 BadDataTools is a personal tool to create sql queries to hunt down `NULL` fields in a database. This is a quick internal tool created for my design style for slick tables in Scala.
 
+Only real use is when the database is not fully in control of a single team, such as when salesforce and the backend services can alter tables or insert data.
+
 ## Features
 
 - Automatic Query Generation – Finds all non-optional fields 


### PR DESCRIPTION
included use case to explain why just not null may not be used on a value which is expected to not be null.